### PR TITLE
updated to reflect changes in nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 name = "cairo"
 version = "0.0.1"
 authors = ["Félix Saparelli <felix@passcod.name>"]
+
+[dependencies]
+num = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cairo"
-version = "0.0.1"
-authors = ["Félix Saparelli <felix@passcod.name>"]
+version = "0.0.2"
+authors = ["Félix Saparelli <felix@passcod.name>", "Tal Levy <tal@fastmail.com>"]
 
 [dependencies]
 num = "*"

--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -151,7 +151,7 @@ impl FontFace {
   pub fn create_toy(family: &str, slant: slant::Slant, weight: weight::Weight) -> FontFace {
     unsafe {
       use std::c_str::ToCStr;
-      let foreign_result = cairo_toy_font_face_create(family.to_c_str().unwrap() as *mut i8, slant, weight);
+      let foreign_result = cairo_toy_font_face_create(family.to_c_str().as_ptr() as *mut i8, slant, weight);
       return FontFace { opaque: foreign_result as *mut libc::c_void };
     }
   }
@@ -266,7 +266,7 @@ impl ScaledFont {
     unsafe {
       use std::c_str::ToCStr;
       let mut extents:TextExtents = std::intrinsics::init();
-      cairo_scaled_font_text_extents(self.opaque, utf8.to_c_str().unwrap() as *mut i8, &mut extents);
+      cairo_scaled_font_text_extents(self.opaque, utf8.to_c_str().as_ptr() as *mut i8, &mut extents);
       return extents;
     }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(missing_copy_implementations)]
+extern crate num;
 extern crate libc;
 #[link(name = "cairo")] extern {}
 
@@ -186,9 +188,10 @@ impl Cairo {
   pub fn get_dash(&mut self) -> (Vec<f64>, f64) {
     unsafe {
       use std::intrinsics;
-      use std::num::Zero;
+      use std::iter::repeat;
+      use num::traits::Zero;
       let dashes_len = self.get_dash_count() as uint;
-      let mut dashes:Vec<f64> = Vec::from_elem(dashes_len, Zero::zero());
+      let mut dashes:Vec<f64> = repeat(Zero::zero()).take(dashes_len).collect();
       let mut offset:f64 = intrinsics::init();
       cairo_get_dash(self.opaque, dashes.as_mut_ptr(), &mut offset);
       return (dashes, offset);
@@ -528,7 +531,7 @@ impl Cairo {
   pub fn text_path(&mut self, text_path: &str) {
     unsafe {
       use std::c_str::ToCStr;
-      cairo_text_path(self.opaque, text_path.to_c_str().unwrap() as *mut i8);
+      cairo_text_path(self.opaque, text_path.to_c_str().as_ptr() as *mut i8);
     }
   }
 
@@ -646,7 +649,7 @@ impl Cairo {
   pub fn select_font_face(&mut self, family: &str, slant: font::slant::Slant, weight: font::weight::Weight) {
     unsafe {
       use std::c_str::ToCStr;
-      cairo_select_font_face(self.opaque, family.to_c_str().unwrap() as *mut i8, slant, weight);
+      cairo_select_font_face(self.opaque, family.to_c_str().as_ptr() as *mut i8, slant, weight);
     }
   }
 
@@ -712,7 +715,7 @@ impl Cairo {
   pub fn show_text(&mut self, utf8: &str) {
     unsafe {
       use std::c_str::ToCStr;
-      cairo_show_text(self.opaque, utf8.to_c_str().unwrap() as *mut i8);
+      cairo_show_text(self.opaque, utf8.to_c_str().as_ptr() as *mut i8);
     }
   }
 
@@ -725,7 +728,7 @@ impl Cairo {
   pub fn show_text_glyphs(&mut self, utf8: &str, glyphs: &mut [font::Glyph], clusters: &mut [font::Cluster], cluster_flags: font::cluster_flags::ClusterFlags) {
     unsafe {
       use std::c_str::ToCStr;
-      cairo_show_text_glyphs(self.opaque, utf8.to_c_str().unwrap() as *mut i8, -1, glyphs.as_mut_ptr(), glyphs.len() as libc::c_int, clusters.as_mut_ptr(), clusters.len() as libc::c_int, cluster_flags);
+      cairo_show_text_glyphs(self.opaque, utf8.to_c_str().as_ptr() as *mut i8, -1, glyphs.as_mut_ptr(), glyphs.len() as libc::c_int, clusters.as_mut_ptr(), clusters.len() as libc::c_int, cluster_flags);
     }
   }
 
@@ -743,7 +746,7 @@ impl Cairo {
       use std::c_str::ToCStr;
       use std::intrinsics;
       let mut extents:font::TextExtents = intrinsics::init();
-      cairo_text_extents(self.opaque, utf8.to_c_str().unwrap() as *mut i8, &mut extents);
+      cairo_text_extents(self.opaque, utf8.to_c_str().as_ptr() as *mut i8, &mut extents);
       return extents;
     }
   }

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -177,7 +177,7 @@ impl Surface {
   pub fn create_from_png(filename: &str) -> Surface {
     unsafe {
       use std::c_str::ToCStr;
-      let foreign_result = cairo_image_surface_create_from_png(filename.to_c_str().unwrap() as *mut i8);
+      let foreign_result = cairo_image_surface_create_from_png(filename.to_c_str().as_ptr() as *mut i8);
       return Surface { opaque: foreign_result as *mut libc::c_void };
     }
   }
@@ -185,7 +185,7 @@ impl Surface {
   pub fn write_to_png(&mut self, filename: &str) -> super::Status {
     unsafe {
       use std::c_str::ToCStr;
-      let foreign_result = cairo_surface_write_to_png(self.opaque, filename.to_c_str().unwrap() as *mut i8);
+      let foreign_result = cairo_surface_write_to_png(self.opaque, filename.to_c_str().as_ptr() as *mut i8);
       return foreign_result;
     }
   }
@@ -193,7 +193,7 @@ impl Surface {
   pub fn create_svg(&mut self, filename: &str, width: f64, height: f64) {
     unsafe {
       use std::c_str::ToCStr;
-      cairo_svg_surface_create(self.opaque, filename.to_c_str().unwrap() as *mut i8, width, height);
+      cairo_svg_surface_create(self.opaque, filename.to_c_str().as_ptr() as *mut i8, width, height);
     }
   }
 


### PR DESCRIPTION
rustc 0.13.0-nightly (ad9e75938 2015-01-05 00:26:28 +0000)
- updated to use new `num` crate's Zero trait
- ignore warnings
- use `as_ptr` for cstring instead of `unwrap`
