### PR TITLE
some create_for_rectangle API fixes

### DIFF
--- a/src/font/mod.rs
+++ b/src/font/mod.rs
@@ -399,10 +399,10 @@ pub struct FontExtents {
 
 #[repr(C)]
 pub struct TextExtents {
-  x_bearing: f64,
-  y_bearing: f64,
-  width: f64,
-  height: f64,
-  max_x_advance: f64,
-  max_y_advance: f64
+  pub x_bearing: f64,
+  pub y_bearing: f64,
+  pub width: f64,
+  pub height: f64,
+  pub max_x_advance: f64,
+  pub max_y_advance: f64
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod pattern;
 pub mod region;
 pub mod surface;
 
+#[derive(Debug)]
 #[repr(i32)]
 pub enum Status {
   Success = 0,

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -25,9 +25,9 @@ impl Surface {
     }
   }
 
-  pub fn create_for_rectangle(x: f64, y: f64, width: f64, height: f64) -> Surface {
+  pub fn create_for_rectangle(&self, x: f64, y: f64, width: f64, height: f64) -> Surface {
     unsafe {
-      let foreign_result = cairo_surface_create_for_rectangle(x, y, width, height);
+      let foreign_result = cairo_surface_create_for_rectangle(self.opaque, x, y, width, height);
       return Surface { opaque: foreign_result as *mut libc::c_void };
     }
   }
@@ -217,7 +217,7 @@ impl Surface {
 
 extern {
   fn cairo_surface_create_similar_image(format: format::Format, width: libc::c_int, height: libc::c_int) -> *mut libc::c_void;
-  fn cairo_surface_create_for_rectangle(x: f64, y: f64, width: f64, height: f64) -> *mut libc::c_void;
+  fn cairo_surface_create_for_rectangle(self_arg: *mut libc::c_void, x: f64, y: f64, width: f64, height: f64) -> *mut libc::c_void;
   fn cairo_surface_status(self_arg: *mut libc::c_void) -> super::Status;
   fn cairo_surface_finish(self_arg: *mut libc::c_void);
   fn cairo_surface_flush(self_arg: *mut libc::c_void);


### PR DESCRIPTION
Make `create_for_rectangle` actually work and make a non-opaque datatype have public values.